### PR TITLE
Ajout Makefile

### DIFF
--- a/src/main/c/Makefile
+++ b/src/main/c/Makefile
@@ -1,0 +1,16 @@
+SOURCES := ${wildcard *.c}
+TARGETS := $(SOURCES:%.c=%)
+
+all: $(TARGETS)
+
+%: %.c
+	gcc -o $@ $< -lm
+	@# If target exists, run it.
+ifeq ($(OS),Windows_NT)
+	@# To do.
+else
+	[ -f ./$@ ] && (./$@ > ./$@.svg)
+endif
+
+clean:
+	rm -rf *.o


### PR DESCRIPTION
Ajout d'un _Makefile_ permettant de compiler un programme et de générer le fichier SVG correspondant (1) en faisant par exemple `make a1` ; ou de compiler tous les programmes d'un coup en faisant `make`.

(1) Reste à ajouter la ligne de commande pour Windows.